### PR TITLE
 Splits on level entry reset fix #6

### DIFF
--- a/Dackage's SM64 LiveSplit AutoSplitter (Full Game, US Binary ROM Hacks Edition).asl
+++ b/Dackage's SM64 LiveSplit AutoSplitter (Full Game, US Binary ROM Hacks Edition).asl
@@ -445,7 +445,7 @@ split
 		#endregion
 		
 		#region Handle key, star count, or level id splits
-		bool levelChanged = current.levelID != old.levelID;
+		bool levelChanged = current.levelID != old.levelID && old.levelID != 1;
 		if (vars.splitContainsKey || vars.splitStarCount != -1)
 		{
 			if (vars.splitOption == null)


### PR DESCRIPTION
i fixed this in aglabs autosplitter but i guess you started making this after i fixed it
basically it allows the first split to be a level entry split for ow1, because without this it'd split 5 seconds after you start up the game (which i doubt anyone wants). 
useful, for example, if you're doing splits for sr7.5 and want to create an opening split for grabbing the super badge, the easiest way to check that is if you reentered ow1 after you exit course.